### PR TITLE
Arcspc1141 addressable dependency update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,7 @@ source 'http://rubygems.org'
 gem 'omniauth', '>= 1.6', :require => false
 gem 'hashie', '>= 1', :require => false
 gem 'omniauth-cas', '>= 1.1', :require => false
+# Addressable and public_suffix are pinned to versions expected by aspace core version 3.3.1.
+# In future upgrades, if they are upgraded in core, this pinning can likely be removed.
 gem 'addressable', '2.8.0', :require => false
 gem 'public_suffix', '4.0.6', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'http://rubygems.org'
 gem 'omniauth', '>= 1.6', :require => false
 gem 'hashie', '>= 1', :require => false
 gem 'omniauth-cas', '>= 1.1', :require => false
-gem 'addressable', '>=2', :require => false
+gem 'addressable', '2.8.0', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ source 'http://rubygems.org'
 gem 'omniauth', '>= 1.6', :require => false
 gem 'hashie', '>= 1', :require => false
 gem 'omniauth-cas', '>= 1.1', :require => false
-
+gem 'addressable', '2.8.0', :require => false
+gem 'public_suffix', '4.0.6', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'http://rubygems.org'
 gem 'omniauth', '>= 1.6', :require => false
 gem 'hashie', '>= 1', :require => false
 gem 'omniauth-cas', '>= 1.1', :require => false
-gem 'addressable', '2.8.0', :require => false
+


### PR DESCRIPTION
Pinned versions of addressable and public_suffix to those used in core aspace v3.3.1:
https://github.com/archivesspace/archivesspace/blob/f0bb058e2fa1922c561d27c5337efe8ff7d2e110/frontend/Gemfile.lock#L45
https://github.com/archivesspace/archivesspace/blob/f0bb058e2fa1922c561d27c5337efe8ff7d2e110/frontend/Gemfile.lock#L197

When installing with these versions pinned, or without the packages defined, addressable is brought in as a dependency of omniauth-cas, and public_suffix as a dependency of addressable. The versions pulled in automatically conflict with those pinned in core aspace.